### PR TITLE
FIX: Correct Vercel runtime configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,20 +1,32 @@
 {
   "version": 2,
-  "buildCommand": "cd client && npm install && npm run build",
-  "outputDirectory": "client/dist",
-  "functions": {
-    "api/*.js": {
-      "runtime": "nodejs18.x"
+  "builds": [
+    {
+      "src": "client/package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "dist" }
+    },
+    {
+      "src": "api/index.js",
+      "use": "@vercel/node"
     }
-  },
+  ],
   "routes": [
     {
       "src": "/api/(.*)",
       "dest": "/api/index.js"
     },
     {
+      "src": "/assets/(.*)",
+      "dest": "/client/dist/assets/$1"
+    },
+    {
+      "src": "/.*\\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot)",
+      "dest": "/client/dist/$0"
+    },
+    {
       "src": "/(.*)",
-      "dest": "/index.html"
+      "dest": "/client/dist/index.html"
     }
   ]
 }


### PR DESCRIPTION
- Remove invalid 'nodejs18.x' runtime specification
- Use proper @vercel/node build configuration
- Fix 'Function Runtimes must have a valid version' error
- Restore working builds array with correct syntax

✅ Vercel deployment should work now