### PR TITLE
FIX: Resolve MIME type error for JavaScript modules

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,18 @@
 {
   "version": 2,
-  "buildCommand": "cd client && npm install && npm run build",
-  "outputDirectory": "client/dist",
-  "functions": {
-    "api/[...routes].js": {
-      "memory": 1024,
-      "maxDuration": 30
+  "builds": [
+    {
+      "src": "client/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    },
+    {
+      "src": "api/[...routes].js",
+      "use": "@vercel/node"
     }
-  },
+  ],
   "routes": [
     {
       "src": "/api/(.*)",
@@ -15,7 +20,7 @@
     },
     {
       "src": "/(.*)",
-      "dest": "/index.html"
+      "dest": "/client/dist/index.html"
     }
   ]
 }


### PR DESCRIPTION
- Switch back to @vercel/static-build for proper static file handling
- Use standard builds array instead of buildCommand/outputDirectory
- This should fix 'Expected a JavaScript module but got text/html' error
- Proper static asset routing for JS/CSS files

✅ Should resolve the blank page and allow React to load properly