### PR TITLE
DEPLOY: Simplify Vercel configuration for reliable deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "npm run dev --prefix client",
-    "build": "cd client && npm install && npm run build && cd ../server && npm install",
+    "build": "cd client && npm install && npm run build && cp -r dist/* ../public/",
     "start": "cd server && npm start",
     "postinstall": "cd client && npm install && cd ../server && npm install"
   },

--- a/vercel.json
+++ b/vercel.json
@@ -1,26 +1,11 @@
 {
-  "version": 2,
-  "builds": [
-    {
-      "src": "client/package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "dist"
-      }
-    },
-    {
-      "src": "api/[...routes].js",
-      "use": "@vercel/node"
+  "buildCommand": "cd client && npm ci && npm run build",
+  "outputDirectory": "client/dist",
+  "installCommand": "npm install",
+  "framework": null,
+  "functions": {
+    "api/[...routes].js": {
+      "runtime": "nodejs18.x"
     }
-  ],
-  "routes": [
-    {
-      "src": "/api/(.*)",
-      "dest": "/api/[...routes].js"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/client/dist/index.html"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
- Use explicit buildCommand and outputDirectory instead of builds array
- Set framework to null to avoid auto-detection issues
- Use nodejs18.x runtime specification
- Simplified approach should resolve 404 NOT_FOUND errors

✅ Using minimal Vercel config that should work reliably